### PR TITLE
Fixed issue that handleScroll was called after destroy

### DIFF
--- a/src/lazyload.js
+++ b/src/lazyload.js
@@ -370,6 +370,10 @@ LazyLoad = function (instanceSettings) {
 
 	this.destroy = function () {
 		_removeEventListener(window, "resize", this.handleScroll);
+        if (_loopTimeout) {
+            clearTimeout(_loopTimeout);
+            _loopTimeout = null;
+        }
 		this._stopScrollHandler();
 		this._elements = null;
 		this._queryOriginNode = null;


### PR DESCRIPTION
I've had some issues when a handleScroll was pending, lazyload was destroyed and I scrolled just before errors showed up complaining settings where undefined.