### PR TITLE
Point "main": in package.json to lazyload script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vanilla-lazyload",
   "version": "1.5.8",
   "description": "LazyLoad is a fast, lightweight and flexible script for loading images only when they're about to enter the viewport of a scrollable area, with an excellent support to the progressive JPEG image format.",
-  "main": "index.html",
+  "main": "dist/lazyload.js",
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.10.0",


### PR DESCRIPTION
Calling `require('vanilla-lazyload')` will fail at the moment due to the fact that `"main":` is not pointing a JS module that exports something.