### PR TITLE
Fix when container is set to null

### DIFF
--- a/src/lazyload.core.js
+++ b/src/lazyload.core.js
@@ -18,7 +18,7 @@ const LazyLoad = function(instanceSettings) {
 
     this._isFirstLoop = true;
     window.addEventListener("resize", this._boundHandleScroll);
-    this.update();
+    this._queryOriginNode && this.update();
 };
 
 LazyLoad.prototype = {


### PR DESCRIPTION
On dynamic websites it can happen, that lazy load is initialized with a query which results in a null as container. This fixes the lazy load code to result in an error.