### PR TITLE
quotes for background image url

### DIFF
--- a/src/lazyload.setSources.js
+++ b/src/lazyload.setSources.js
@@ -28,5 +28,5 @@ export default function(element, srcsetDataAttribute, srcDataAttribute) {
         if (elementSrc) { element.setAttribute("src", elementSrc); }
         return;
     }
-    if (elementSrc) { element.style.backgroundImage = "url(" + elementSrc + ")"; }
+    if (elementSrc) { element.style.backgroundImage = "url('" + elementSrc + "')"; }
 };


### PR DESCRIPTION
Without qoutes image doesn't load for some files, for example:
tiz_593_430_11243_(black)_w_white-shoes__nk.597AF9C2.jpg
image (1).jpg

Tested in Google Chrome 59.0.3071.115