### PR TITLE
Fix invalid CSS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,8 +459,8 @@ According to what reported in #152, for Microsoft Edge to fire the IntersectionO
 By setting the following, edge is able to see the images and they get loaded.
 
 ```css
-img["data-src"],
-img["data-srcset"] {
+img[data-src],
+img[data-srcset] {
   display: block;
   min-height: 1px;
 }


### PR DESCRIPTION
The CSS in readme was invalid. To target images with a `data-src` attribute the correct CSS selector would be: `img[data-src]` (no quotes).