### PR TITLE
Add trigger to load video after source is set

### DIFF
--- a/src/lazyload.setSources.js
+++ b/src/lazyload.setSources.js
@@ -56,6 +56,8 @@ export const setSourcesVideo = (element, settings) => {
 
 	setSourcesInChildren(element, "src", srcDataName);
 	setAttributeIfValue(element, "src", srcDataValue);
+
+	element.load();
 };
 
 export const setSourcesBgImage = (element, settings) => {


### PR DESCRIPTION
Addresses https://github.com/verlok/lazyload/issues/240
Tested on the latest versions of Chrome, Firefox and Edge, with and without the `autoplay` attribute.