### PR TITLE
[Fix bug in Chrome] Remove entry.isIntersecting

### DIFF
--- a/src/lazyload.intersectionObserver.js
+++ b/src/lazyload.intersectionObserver.js
@@ -1,7 +1,4 @@
-/* entry.isIntersecting needs fallback because is null on some versions of MS Edge, and
-   entry.intersectionRatio is not enough alone because it could be 0 on some intersecting elements */
-export const isIntersecting = entry =>
-	entry.isIntersecting || entry.intersectionRatio > 0;
+export const isIntersecting = entry => entry.intersectionRatio > 0;
 
 export const getObserverSettings = settings => ({
 	root: settings.container === document ? null : settings.container,


### PR DESCRIPTION
The fix related to this issue https://github.com/verlok/lazyload/issues/293

