### PR TITLE
Fixed typo that broke tests

### DIFF
--- a/__tests__/lazyload.setSources.test.js
+++ b/__tests__/lazyload.setSources.test.js
@@ -1,4 +1,4 @@
-import { setSources } from "../src/lazyLoad.setSources";
+import { setSources } from "../src/lazyload.setSources";
 import expectExtend from "./lib/expectExtend";
 import getFakeInstance from "./lib/getFakeInstance";
 


### PR DESCRIPTION
Seems that in a recent refactor the filenames were changed, and that broke the tests.

This fixes the import so the tests work again!