### PR TITLE
ignore everything but dist/ folder from npm release builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,11 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Directories and files to ignore from release archives
+.github/ export-ignore
+__tests__/ export-ignore
+demos/ export-ignore
+img/ export-ignore
+src/ export-ignore
+typings/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -27,4 +27,3 @@ __tests__/ export-ignore
 demos/ export-ignore
 img/ export-ignore
 src/ export-ignore
-typings/ export-ignore


### PR DESCRIPTION
Closes https://github.com/verlok/lazyload/issues/379

To not unnecessarily clutter this file with everything contained on the top level as a file I just dont mention them. We save by ignoring the „unrelated“ folders already 95% 