### PR TITLE
Fix TypeScript error 7013

### DIFF
--- a/typings/lazyload.d.ts
+++ b/typings/lazyload.d.ts
@@ -20,7 +20,7 @@
 	use_native?: boolean;
 }
 interface ILazyLoad {
-	new (options?: ILazyLoadOptions, elements?: NodeListOf<HTMLElement>);
+	new (options?: ILazyLoadOptions, elements?: NodeListOf<HTMLElement>): ILazyLoad;
 	update: (elements?: NodeListOf<HTMLElement>) => void;
 	destroy: () => void;
 	load: (element: HTMLElement, force?: boolean) => void;


### PR DESCRIPTION
This fixes the typescript error which I had: "Construct signature, which lacks return-type annotation, implicitly has an 'any' return type.".
A reference to the error can be found here: https://github.com/microsoft/TypeScript/blame/a44d8e76c68e7c685cef3d34943158021acd04e5/src/compiler/diagnosticMessages.json#L2311