### PR TITLE
Implement takeRecords in Update to reduce flickers

### DIFF
--- a/src/lazyload.intersectionObserver.js
+++ b/src/lazyload.intersectionObserver.js
@@ -9,16 +9,25 @@ export const getObserverSettings = settings => ({
 	rootMargin: settings.thresholds || settings.threshold + "px"
 });
 
+export const processObserverEntries = entries => {
+	entries.forEach(entry =>
+		isIntersecting(entry)
+			? onEnter(entry.target, instance)
+			: onExit(entry.target, instance)
+	);
+};
+
+export const takeRecords = instance => {
+	if (!supportsIntersectionObserver || !instance._observer.takeRecords) {
+		return;
+	}
+	processObserverEntries(instance._observer.takeRecords());	
+};
+
 export const setObserver = instance => {
 	if (!supportsIntersectionObserver) {
 		return false;
 	}
-	instance._observer = new IntersectionObserver(entries => {
-		entries.forEach(entry =>
-			isIntersecting(entry)
-				? onEnter(entry.target, instance)
-				: onExit(entry.target, instance)
-		);
-	}, getObserverSettings(instance._settings));
+	instance._observer = new IntersectionObserver(processObserverEntries, getObserverSettings(instance._settings));
 	return true;
 };

--- a/src/lazyload.js
+++ b/src/lazyload.js
@@ -1,7 +1,7 @@
 import getInstanceSettings from "./lazyload.defaults";
 import autoInitialize from "./lazyload.autoInitialize";
 import { revealElement, revealAndUnobserve } from "./lazyload.reveal";
-import { setObserver } from "./lazyload.intersectionObserver";
+import { setObserver, takeRecords } from "./lazyload.intersectionObserver";
 import { isBot, runningOnBrowser } from "./lazyload.environment";
 import { shouldUseNative, loadAllNative } from "./lazyload.native";
 import { getElements } from "./lazyload.getElements";
@@ -30,6 +30,7 @@ LazyLoad.prototype = {
 		this._elements.forEach(element => {
 			this._observer.observe(element);
 		});
+		takeRecords(this);
 	},
 
 	destroy: function() {


### PR DESCRIPTION
Hello,

When using React and adding some elements, if they're visible on screen it can flicker from a placeholder existing "src" to the new "data-src". Using takeRecords in update() it's possible to swap the "src" before a render so the flicker is greatly reduced.

This PR implements that.